### PR TITLE
Add information/configuration for local development

### DIFF
--- a/.env-sample
+++ b/.env-sample
@@ -1,0 +1,14 @@
+# Set to 'production' when deployed
+RACK_ENV=development
+
+MONGO_URI=
+
+# https://pingometer.com/
+PINGOMETER_USER=
+PINGOMETER_PASS=
+
+# Only necessary in production
+AWS_KEY=
+AWS_SECRET=
+AWS_BUCKET=
+AWS_REGION=

--- a/README.md
+++ b/README.md
@@ -25,6 +25,19 @@ Both sites are powered by same underlying monitoring infrastructure. At the mome
 
 Thanks for being interested! First, check out the [issues list](https://github.com/codeforamerica/snap-it-up/issues). Some of the work there is discussion, exploration, and thinking. Feel free to pose questions or read through the discussions if you'd like to pitch in or learn more. Some of the issues are about the actual source code in this repo. If you'd like to contribute code or suggest new things to be added to the site, feel free to add to those issues.
 
+## Local Development
+
+Follow these steps in order to run the application locally:
+
+0. Have a Ruby development environment created. These steps assume you are using Bundler for package management and Foreman managing environment variables.
+1. Copy `.env-sample` to `.env`. This is where you will be saving configuration for steps 2 and 3.
+2. Provision a Mongo database. This can either be done locally, or by setting up a free cloud database through [MongoLab](https://mongolab.com)
+3. Create a [Pingometer](http://pingometer.com) account. 
+4. Create a new pingometer check for a website listed in `public/data/pingometer_monitors.json` with 1 minute resolution and make note of its id (look in the url: `monitors/{monitor_id}`)
+5. Update `public/data/pingometer_monitors.json` with your new check's id (be sure NOT to ever git commit this change)
+6. Run `$ foreman run bundle exec rake pingometer:load_events[{monitor_id}]`. If you set up the previous correctly, it should run successfully
+7. To start the server, run `$ foreman start` and visit `http://localhost:5000`. You should see a single state outline that corresponds to the state you copy-pasted in step number 3.
+
 ## Licensing
 
 This project is open source and licensed under the [BSD 3-clause license][LICENSE].

--- a/app.rb
+++ b/app.rb
@@ -32,8 +32,8 @@ get '/' do
   # Get basic info on all monitors.
   begin
     monitors = Pingometer.new(PINGOMETER_USER, PINGOMETER_PASS).monitors
-  rescue
-    @error_message = "Our status monitoring system, Pingometer, appears to be having problems."
+  rescue => error
+    @error_message = "Our status monitoring system, Pingometer, appears to be having problems. #{error}"
     return erb :error
   end
   


### PR DESCRIPTION
I added the instructions I took set things up below, but it's kinda messy. Particularly challenging is that `pingometer_monitors.json` has hardcoded Pingometer ids, which makes development without access to the Production pingometer account kinda nasty :-/
