### PR TITLE
Snapshotter improvements, browserstack support

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,3 +8,6 @@ gem "aws-sdk"
 gem "mongo"
 gem "bson_ext"
 gem "rake"
+
+# For browserstack
+gem "selenium-webdriver"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,6 +14,9 @@ GEM
     bson_ext (1.12.0)
       bson (~> 1.12.0)
     builder (3.2.2)
+    childprocess (0.5.5)
+      ffi (~> 1.0, >= 1.0.11)
+    ffi (1.9.6)
     httparty (0.13.3)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -30,6 +33,12 @@ GEM
       rack
     raindrops (0.13.0)
     rake (10.4.2)
+    rubyzip (1.0.0)
+    selenium-webdriver (2.45.0)
+      childprocess (~> 0.5)
+      multi_json (~> 1.0)
+      rubyzip (~> 1.0)
+      websocket (~> 1.0)
     sinatra (1.4.5)
       rack (~> 1.4)
       rack-protection (~> 1.4)
@@ -39,6 +48,7 @@ GEM
       kgio (~> 2.6)
       rack
       raindrops (~> 0.7)
+    websocket (1.2.1)
 
 PLATFORMS
   ruby
@@ -49,5 +59,6 @@ DEPENDENCIES
   httparty
   mongo
   rake
+  selenium-webdriver
   sinatra
   unicorn

--- a/app.rb
+++ b/app.rb
@@ -5,6 +5,7 @@ require 'json'
 require 'fileutils'
 require './lib/pingometer.rb'
 require './lib/pagesnap.rb'
+require './lib/browserstack.rb'
 require 'aws-sdk'
 require 'httparty'
 require 'mongo'
@@ -18,13 +19,19 @@ AWS_REGION = ENV['AWS_REGION']
 PRODUCTION = ENV['RACK_ENV'] == 'production'
 MONGO_URI = ENV['MONGO_URI'] || ENV['MONGOLAB_URI'] || "mongodb://localhost:27017/snap_it_up"
 PAGESNAP_URL = ENV['PAGESNAP_URL']
+BROWSERSTACK_USER = ENV['BROWSERSTACK_USER']
+BROWSERSTACK_KEY = ENV['BROWSERSTACK_KEY']
 
 Aws.config.merge!({
   credentials: Aws::Credentials.new(AWS_KEY, AWS_SECRET),
   region: AWS_REGION || 'us-east-1'
 })
 
-Snapshotter = PageSnap.new(PAGESNAP_URL)
+if BROWSERSTACK_USER && BROWSERSTACK_KEY
+  Snapshotter = Browserstack.new(BROWSERSTACK_USER, BROWSERSTACK_KEY)
+else
+  Snapshotter = PageSnap.new(PAGESNAP_URL)
+end
 
 MonitorList = JSON.parse(File.read('public/data/pingometer_monitors.json'))
 

--- a/lib/browserstack.rb
+++ b/lib/browserstack.rb
@@ -1,0 +1,20 @@
+require 'selenium-webdriver'
+
+class Browserstack
+  def initialize(user, key)
+    @user = user
+    @key = key
+  end
+  
+  def get_url
+    "http://#{BROWSERSTACK_USER}:#{BROWSERSTACK_KEY}@hub.browserstack.com/wd/hub"
+  end
+  
+  def snapshot(url)
+    driver = Selenium::WebDriver.for(:remote,
+      :url => get_url,
+      :desired_capabilities => Selenium::WebDriver::Remote::Capabilities.firefox)
+    driver.navigate.to url
+    driver.screenshot_as(:png)
+  end
+end

--- a/lib/pagesnap.rb
+++ b/lib/pagesnap.rb
@@ -1,0 +1,9 @@
+class PageSnap
+  def initialize(base_url=nil)
+    @base_url = base_url || "http://pagesnap.herokuapp.com"
+  end
+  
+  def snapshot(url)
+    HTTParty.get("#{@base_url}/#{CGI.escape(url)}.png", :timeout => 20).parsed_response
+  end
+end

--- a/tasks/snapshot_states.rb
+++ b/tasks/snapshot_states.rb
@@ -3,8 +3,6 @@
 require 'optparse'
 require './app.rb'
 
-PAGESNAP_URL = ENV['PAGESNAP_URL'] || "http://pagesnap.herokuapp.com"
-
 states = []
 time_zones = []
 monitors = []
@@ -38,7 +36,7 @@ monitors.each do |monitor_info|
   puts "Snapshotting #{page_url}"
   snapshot = nil
   begin
-    snapshot = HTTParty.get("#{PAGESNAP_URL}/#{CGI.escape(page_url)}.png", :timeout => 20).parsed_response
+    snapshot = Snapshotter.snapshot page_url
   rescue
     snapshot = File.read("public/images/unreachable.png")
   end


### PR DESCRIPTION
Some improvements to snapshotting:
1. Encapsulate the snapshotting logic in its own class/file.
2. Make an implementation for browserstack. The API contract is that a snapshotter must implement the method `snapshot(url)`.
3. If we have browserstack credentials configured, use browserstack for snapshotting. Otherwise, fall back to PageSnap (less reliable/stable/capable).

Browserstack config is two env vars: `BROWSERSTACK_USER`, `BROWSERSTACK_KEY`.
