### PR TITLE
HOTFIX: incorrect nil check in uptime calculator on home page

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -272,7 +272,7 @@ def state_uptimes_between(t1, t2)
         end
       end
       
-      if monitor_time
+      if monitor_time > 0
         (monitor_time - downtime) / monitor_time
       else
         1000


### PR DESCRIPTION
Not sure how this logic error persisted so long. Clearly I wrote it thinking 0 would be falsy, which is not the case in Ruby.

This is actually already in production on Heroku because it’s so straightforward *[cringe]*.